### PR TITLE
feat: [#10] enforce double quotes in yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     groups:
       github-actions-all:
         patterns:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -11,6 +11,7 @@ jobs:
         args:
           - testing-type: lint-commit
           - testing-type: lint-git
+          - testing-type: security-file-system
           - testing-type: yamllint
     runs-on: ubuntu-24.04
     steps:
@@ -18,3 +19,4 @@ jobs:
       - uses: ./
         with:
           testing-type: ${{ matrix.args.testing-type }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
       - uses: schubergphilis/mcvs-general-action@v0.4.0
         with:
           testing-type: ${{ matrix.args.testing-type }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 | Option               | Default | Required |

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: |
       OCI repository to retrieve trivy-java-db from.
 runs:
-  using: "composite"
+  using: composite
   steps:
     - if: |
         github.event_name == 'pull_request' &&

--- a/configs/yamllint.yaml
+++ b/configs/yamllint.yaml
@@ -5,3 +5,6 @@ rules:
     min-spaces-from-content: 1
   document-start:
     level: error
+  quoted-strings:
+    quote-type: double
+    required: only-when-needed


### PR DESCRIPTION
* `string value is redundantly quoted with double quotes`.
* Use quotes for strings only if required.
* If single quotes, then pipeline fails and double quotes are needed.