### PR TITLE
fix: zizmor advanced security false for private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,15 @@ The Mission Critical Vulnerability Scanner (MCVS) General Action provides automa
 ### Available Testing Types
 
 - **`lint-action`**: Validates GitHub Actions workflow files for security issues
-
   - Uses [zizmor](https://github.com/zizmorcore/zizmor) to detect security vulnerabilities
   - Checks at minimum `low` severity level
 
 - **`lint-commit`**: Validates commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
-
   - Checks all commits in pull request range
   - Enforces conventional commit standards (feat, fix, docs, etc.)
   - Configuration: `configs/commitlint.config.mjs`
 
 - **`lint-git`**: Enforces Git workflow best practices
-
   - Ensures feature branch is up-to-date with main (no commits behind)
   - Detects and blocks unwanted merges of main into feature branches
   - Identifies fixup/squash commits that should be squashed before merge
@@ -33,7 +30,6 @@ The Mission Critical Vulnerability Scanner (MCVS) General Action provides automa
 - **`security-file-system`**: Reserved for future use
 
 - **`yamllint`**: Validates YAML file formatting
-
   - Checks all YAML files against formatting standards
   - Uses hash-pinned dependencies for security
   - Configuration: `configs/yamllint.yaml`
@@ -88,9 +84,10 @@ jobs:
 
 ## Inputs
 
-| Input        | Description                                       | Required | Default |
-| :----------- | :------------------------------------------------ | :------- | :------ |
-| testing-type | Type of test to run (see Available Testing Types) | Yes      | N/A     |
+| Input                           | Description                                       | Required | Default |
+| :------------------------------ | :------------------------------------------------ | :------- | :------ |
+| testing-type                    | Type of test to run (see Available Testing Types) | Yes      | N/A     |
+| zizmor-action-advanced-security | Disable advanced security report upload           | No       | true    |
 
 ### Advanced Inputs (yamllint customization)
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   yamllint-dependency-pyyaml-sha256-hash:
     default: ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
     description: The sha256 hash of a certain PyYAML package.
+  zizmor-action-advanced-security:
+    default: "true"
+    description: Upload results to Advanced Security or not.
 runs:
   using: composite
   steps:
@@ -43,6 +46,7 @@ runs:
       # yamllint disable-line rule:line-length
       uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
       with:
+        advanced-security: ${{ inputs.zizmor-action-advanced-security }}
         min-severity: low
     - if: |
         github.event_name == 'pull_request' &&


### PR DESCRIPTION
Zizmor advanced security false for private repositories. Apart from that, the zizmor action works for private repository, but this option disables the upload of the report that is failing for private repositories.