### PR TITLE
fix: ignore openspec from yamllint

### DIFF
--- a/configs/yamllint.yaml
+++ b/configs/yamllint.yaml
@@ -1,5 +1,7 @@
 ---
 extends: default
+ignore:
+  - openspec
 rules:
   comments:
     min-spaces-from-content: 1


### PR DESCRIPTION
Openspec does not a document-start to YAML files so those files will never pass the linter. In order to prevent that, omit openspec directory from yamllint.